### PR TITLE
Use Priority to support synchronous crypto on NodeJS

### DIFF
--- a/core/js/src/main/scala/bobcats/CryptoPlatform.scala
+++ b/core/js/src/main/scala/bobcats/CryptoPlatform.scala
@@ -17,9 +17,10 @@
 package bobcats
 
 import cats.effect.kernel.Async
+import cats.effect.kernel.Sync
 
 private[bobcats] trait CryptoCompanionPlatform {
-  implicit def forMonadThrow[F[_]: Async]: Crypto[F] =
+  implicit def forAsyncOrSync[F[_]](implicit F: Priority[Async[F], Sync[F]]): Crypto[F] =
     new UnsealedCrypto[F] {
       override def hash: Hash[F] = Hash[F]
       override def hmac: Hmac[F] = Hmac[F]

--- a/core/js/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HashPlatform.scala
@@ -35,7 +35,7 @@ private[bobcats] trait HashCompanionPlatform {
       }
     else
       F.getPreferred
-        .map { implicit F =>
+        .map { implicit F: Async[F] =>
           new UnsealedHash[F] {
             import facade.browser._
             override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] =

--- a/core/js/src/main/scala/bobcats/HmacPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HmacPlatform.scala
@@ -57,8 +57,10 @@ private[bobcats] trait HmacCompanionPlatform {
               )
             }
           } { F =>
-            F.catchNonFatal {
-              crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
+            F.delay {
+              val key =
+                crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
+              SecretKeySpec(ByteVector.view(key.`export`()), algorithm)
             }
           }
 

--- a/core/js/src/main/scala/bobcats/HmacPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HmacPlatform.scala
@@ -30,7 +30,7 @@ private[bobcats] trait HmacCompanionPlatform {
     if (facade.isNodeJSRuntime)
       new UnsealedHmac[F] {
         import facade.node._
-        implicit val F = F0.join[Sync[F]]
+        implicit val F: Sync[F] = F0.join[Sync[F]]
 
         override def digest(key: SecretKey[HmacAlgorithm], data: ByteVector): F[ByteVector] =
           key match {
@@ -72,7 +72,7 @@ private[bobcats] trait HmacCompanionPlatform {
       }
     else
       F0.getPreferred
-        .map { implicit F =>
+        .map { implicit F: Async[F] =>
           new UnsealedHmac[F] {
             import bobcats.facade.browser._
             override def digest(

--- a/core/js/src/main/scala/bobcats/HmacPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HmacPlatform.scala
@@ -21,14 +21,16 @@ import cats.syntax.all._
 import scodec.bits.ByteVector
 
 import scala.scalajs.js
+import cats.effect.kernel.Sync
 
 private[bobcats] trait HmacPlatform[F[_]]
 
 private[bobcats] trait HmacCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): Hmac[F] =
+  implicit def forAsyncOrSync[F[_]](implicit F0: Priority[Async[F], Sync[F]]): Hmac[F] =
     if (facade.isNodeJSRuntime)
       new UnsealedHmac[F] {
         import facade.node._
+        implicit val F = F0.join[Sync[F]]
 
         override def digest(key: SecretKey[HmacAlgorithm], data: ByteVector): F[ByteVector] =
           key match {
@@ -42,16 +44,22 @@ private[bobcats] trait HmacCompanionPlatform {
           }
 
         override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
-          F.async_ { cb =>
-            crypto.generateKey(
-              "hmac",
-              GenerateKeyOptions(algorithm.minimumKeyLength),
-              (err, key) =>
-                cb(
-                  Option(err)
-                    .map(js.JavaScriptException)
-                    .toLeft(SecretKeySpec(ByteVector.view(key.`export`()), algorithm)))
-            )
+          F0.fold { F =>
+            F.async_[SecretKey[A]] { cb =>
+              crypto.generateKey(
+                "hmac",
+                GenerateKeyOptions(algorithm.minimumKeyLength),
+                (err, key) =>
+                  cb(
+                    Option(err)
+                      .map(js.JavaScriptException)
+                      .toLeft(SecretKeySpec(ByteVector.view(key.`export`()), algorithm)))
+              )
+            }
+          } { F =>
+            F.catchNonFatal {
+              crypto.generateKeySync("hmac", GenerateKeyOptions(algorithm.minimumKeyLength))
+            }
           }
 
         override def importKey[A <: HmacAlgorithm](
@@ -61,44 +69,52 @@ private[bobcats] trait HmacCompanionPlatform {
 
       }
     else
-      new UnsealedHmac[F] {
-        import bobcats.facade.browser._
-        override def digest(key: SecretKey[HmacAlgorithm], data: ByteVector): F[ByteVector] =
-          key match {
-            case SecretKeySpec(key, algorithm) =>
+      F0.getPreferred
+        .map { implicit F =>
+          new UnsealedHmac[F] {
+            import bobcats.facade.browser._
+            override def digest(
+                key: SecretKey[HmacAlgorithm],
+                data: ByteVector): F[ByteVector] =
+              key match {
+                case SecretKeySpec(key, algorithm) =>
+                  for {
+                    key <- F.fromPromise(
+                      F.delay(
+                        crypto
+                          .subtle
+                          .importKey(
+                            "raw",
+                            key.toUint8Array,
+                            HmacImportParams(algorithm.toStringWebCrypto),
+                            false,
+                            js.Array("sign"))))
+                    signature <- F.fromPromise(
+                      F.delay(crypto.subtle.sign("HMAC", key, data.toUint8Array.buffer)))
+                  } yield ByteVector.view(signature)
+                case _ => F.raiseError(new InvalidKeyException)
+              }
+
+            override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
               for {
                 key <- F.fromPromise(
                   F.delay(
                     crypto
                       .subtle
-                      .importKey(
-                        "raw",
-                        key.toUint8Array,
-                        HmacImportParams(algorithm.toStringWebCrypto),
-                        false,
+                      .generateKey(
+                        HmacKeyGenParams(algorithm.toStringWebCrypto),
+                        true,
                         js.Array("sign"))))
-                signature <- F.fromPromise(
-                  F.delay(crypto.subtle.sign("HMAC", key, data.toUint8Array.buffer)))
-              } yield ByteVector.view(signature)
-            case _ => F.raiseError(new InvalidKeyException)
+                exported <- F.fromPromise(F.delay(crypto.subtle.exportKey("raw", key)))
+              } yield SecretKeySpec(ByteVector.view(exported), algorithm)
+
+            override def importKey[A <: HmacAlgorithm](
+                key: ByteVector,
+                algorithm: A): F[SecretKey[A]] =
+              F.pure(SecretKeySpec(key, algorithm))
           }
+        }
+        .getOrElse(throw new UnsupportedOperationException(
+          "Hmac[F] on browsers requires Async[F]"))
 
-        override def generateKey[A <: HmacAlgorithm](algorithm: A): F[SecretKey[A]] =
-          for {
-            key <- F.fromPromise(
-              F.delay(
-                crypto
-                  .subtle
-                  .generateKey(
-                    HmacKeyGenParams(algorithm.toStringWebCrypto),
-                    true,
-                    js.Array("sign"))))
-            exported <- F.fromPromise(F.delay(crypto.subtle.exportKey("raw", key)))
-          } yield SecretKeySpec(ByteVector.view(exported), algorithm)
-
-        override def importKey[A <: HmacAlgorithm](
-            key: ByteVector,
-            algorithm: A): F[SecretKey[A]] =
-          F.pure(SecretKeySpec(key, algorithm))
-      }
 }

--- a/core/js/src/main/scala/bobcats/Priority.scala
+++ b/core/js/src/main/scala/bobcats/Priority.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bobcats
+
+/**
+ * Priority is a type class for prioritized implicit search.
+ *
+ * This type class will attempt to provide an implicit instance of `P` (the preferred type). If
+ * that type is not available it will fallback to `F` (the fallback type). If neither type is
+ * available then a `Priority[P, F]` instance will not be available.
+ *
+ * This type can be useful for problems where multiple algorithms can be used, depending on the
+ * type classes available.
+ */
+sealed trait Priority[+P, +F] {
+
+  import Priority.{Fallback, Preferred}
+
+  def fold[B](f1: P => B)(f2: F => B): B =
+    this match {
+      case Preferred(x) => f1(x)
+      case Fallback(y) => f2(y)
+    }
+
+  def join[U >: P with F]: U =
+    fold(_.asInstanceOf[U])(_.asInstanceOf[U])
+
+  def bimap[P2, F2](f1: P => P2)(f2: F => F2): Priority[P2, F2] =
+    this match {
+      case Preferred(x) => Preferred(f1(x))
+      case Fallback(y) => Fallback(f2(y))
+    }
+
+  def toEither: Either[P, F] =
+    fold[Either[P, F]](p => Left(p))(f => Right(f))
+
+  def isPreferred: Boolean =
+    fold(_ => true)(_ => false)
+
+  def isFallback: Boolean =
+    fold(_ => false)(_ => true)
+
+  def getPreferred: Option[P] =
+    fold[Option[P]](p => Some(p))(_ => None)
+
+  def getFallback: Option[F] =
+    fold[Option[F]](_ => None)(f => Some(f))
+}
+
+object Priority extends FindPreferred {
+
+  case class Preferred[P](get: P) extends Priority[P, Nothing]
+  case class Fallback[F](get: F) extends Priority[Nothing, F]
+
+  def apply[P, F](implicit ev: Priority[P, F]): Priority[P, F] = ev
+}
+
+private[bobcats] trait FindPreferred extends FindFallback {
+  implicit def preferred[P](implicit ev: P): Priority[P, Nothing] =
+    Priority.Preferred(ev)
+}
+
+private[bobcats] trait FindFallback {
+  implicit def fallback[F](implicit ev: F): Priority[Nothing, F] =
+    Priority.Fallback(ev)
+}

--- a/core/js/src/main/scala/bobcats/facade/node/crypto.scala
+++ b/core/js/src/main/scala/bobcats/facade/node/crypto.scala
@@ -35,6 +35,8 @@ private[bobcats] trait crypto extends js.Any {
       options: GenerateKeyOptions,
       callback: js.Function2[js.Error, SymmetricKeyObject, Unit]): Unit = js.native
 
+  def generateKeySync(`type`: String, options: GenerateKeyOptions): Unit = js.native
+
   def randomBytes(size: Int): js.typedarray.Uint8Array = js.native
 
   def randomBytes(

--- a/core/js/src/main/scala/bobcats/facade/node/crypto.scala
+++ b/core/js/src/main/scala/bobcats/facade/node/crypto.scala
@@ -35,7 +35,8 @@ private[bobcats] trait crypto extends js.Any {
       options: GenerateKeyOptions,
       callback: js.Function2[js.Error, SymmetricKeyObject, Unit]): Unit = js.native
 
-  def generateKeySync(`type`: String, options: GenerateKeyOptions): Unit = js.native
+  def generateKeySync(`type`: String, options: GenerateKeyOptions): SymmetricKeyObject =
+    js.native
 
   def randomBytes(size: Int): js.typedarray.Uint8Array = js.native
 


### PR DESCRIPTION
Sacrifices some type-safety for greater flexibility. Blame the lack of separate NodeJS and browser platforms.