### PR TITLE
Test both sync and async implementations on Node.js

### DIFF
--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -16,9 +16,14 @@
 
 package bobcats
 
-import munit.CatsEffectSuite
+import cats.Functor
 import cats.effect.IO
+import cats.effect.SyncIO
+import cats.syntax.all._
+import munit.CatsEffectSuite
 import scodec.bits.ByteVector
+
+import scala.reflect.ClassTag
 
 class HashSuite extends CatsEffectSuite {
 
@@ -26,20 +31,32 @@ class HashSuite extends CatsEffectSuite {
 
   val data = ByteVector.encodeAscii("The quick brown fox jumps over the lazy dog").toOption.get
 
-  def testHash(algorithm: HashAlgorithm, expect: String) =
-    test(algorithm.toString) {
-      assertIO(
-        Hash[IO].digest(algorithm, data),
-        ByteVector.fromHex(expect).get
-      )
+  def testHash[F[_]: Hash: Functor](algorithm: HashAlgorithm, expect: String)(
+      implicit ct: ClassTag[F[_]]) =
+    test(s"$algorithm with ${ct.runtimeClass.getSimpleName()}") {
+      Hash[F].digest(algorithm, data).map { obtained =>
+        assertEquals(
+          obtained,
+          ByteVector.fromHex(expect).get
+        )
+      }
+
     }
 
+  def tests[F[_]: Hash: Functor](implicit ct: ClassTag[F[_]]) = {
+    if (Set("JVM", "NodeJS").contains(BuildInfo.runtime))
+      testHash[F](MD5, "9e107d9d372bb6826bd81d3542a419d6")
+    testHash[F](SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+    testHash[F](SHA256, "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
+    testHash[F](
+      SHA512,
+      "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
+  }
+
   if (Set("JVM", "NodeJS").contains(BuildInfo.runtime))
-    testHash(MD5, "9e107d9d372bb6826bd81d3542a419d6")
-  testHash(SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
-  testHash(SHA256, "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
-  testHash(
-    SHA512,
-    "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
+    tests[SyncIO]
+
+  if (BuildInfo.runtime != "JVM")
+    tests[IO]
 
 }

--- a/core/shared/src/test/scala/bobcats/HmacSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HmacSuite.scala
@@ -16,9 +16,14 @@
 
 package bobcats
 
-import munit.CatsEffectSuite
+import cats.Functor
 import cats.effect.IO
+import cats.effect.SyncIO
+import cats.syntax.all._
+import munit.CatsEffectSuite
 import scodec.bits.ByteVector
+
+import scala.reflect.ClassTag
 
 class HmacSuite extends CatsEffectSuite {
 
@@ -27,30 +32,47 @@ class HmacSuite extends CatsEffectSuite {
   val key = ByteVector.encodeAscii("key").toOption.get
   val data = ByteVector.encodeAscii("The quick brown fox jumps over the lazy dog").toOption.get
 
-  def testHash(algorithm: HmacAlgorithm, expect: String) =
-    test(algorithm.toString) {
-      assertIO(
-        Hmac[IO].digest(SecretKeySpec(key, algorithm), data),
-        ByteVector.fromHex(expect).get
-      )
+  def testHmac[F[_]: Hmac: Functor](algorithm: HmacAlgorithm, expect: String)(
+      implicit ct: ClassTag[F[_]]) =
+    test(s"$algorithm with ${ct.runtimeClass.getSimpleName()}") {
+      Hmac[F].digest(SecretKeySpec(key, algorithm), data).map { obtained =>
+        assertEquals(
+          obtained,
+          ByteVector.fromHex(expect).get
+        )
+      }
     }
 
-  testHash(SHA1, "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9")
-  testHash(SHA256, "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8")
-  testHash(
-    SHA512,
-    "b42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3a")
+  def tests[F[_]: Hmac: Functor](implicit ct: ClassTag[F[_]]) = {
+    testHmac[F](SHA1, "de7c9b85b8b78aa6bc8a7a36f70a90701c9db4d9")
+    testHmac[F](SHA256, "f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8")
+    testHmac[F](
+      SHA512,
+      "b42af09057bac1e2d41708e48a902e09b5ff7f12ab428a4fe86653c73dd248fb82f948a549f7b791a5b41915ee4d1ec3935357e4e2317250d0372afa2ebeeb3a")
+  }
 
-  def testGenerateKey(algorithm: HmacAlgorithm) =
-    test(s"generate key for ${algorithm}") {
-      Hmac[IO].generateKey(algorithm).map {
+  def testGenerateKey[F[_]: Functor: Hmac](algorithm: HmacAlgorithm)(
+      implicit ct: ClassTag[F[_]]) =
+    test(s"generate key for ${algorithm} with ${ct.runtimeClass.getSimpleName()}") {
+      Hmac[F].generateKey(algorithm).map {
         case SecretKeySpec(key, keyAlgorithm) =>
           assertEquals(algorithm, keyAlgorithm)
           assert(key.size >= algorithm.minimumKeyLength)
       }
     }
 
-  if (BuildInfo.runtime != "NodeJS") // Disabled until testing against Node 16
-    List(SHA1, SHA256, SHA512).foreach(testGenerateKey)
+  if (Set("JVM", "NodeJS").contains(BuildInfo.runtime))
+    tests[SyncIO]
+
+  if (BuildInfo.runtime != "JVM")
+    tests[IO]
+
+  if (BuildInfo.runtime == "JVM")
+    List(SHA1, SHA256, SHA512).foreach(testGenerateKey[SyncIO])
+
+  if (!Set("JVM", "NodeJS").contains(
+      BuildInfo.runtime
+    )) // Disabled until testing against Node 16
+    List(SHA1, SHA256, SHA512).foreach(testGenerateKey[IO])
 
 }


### PR DESCRIPTION
This is a follow-up to #11, which added alternative implementations for Node.js that don't require an `Async` constraint but neglected to add tests for them.