### PR TITLE
Introduces incremental hash.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -78,6 +78,7 @@ ThisBuild / Test / jsEnv := {
 }
 
 val catsVersion = "2.8.0"
+val fs2Version = "3.7.0"
 val catsEffectVersion = "3.5.1"
 val scodecBitsVersion = "1.1.35"
 val munitVersion = "1.0.0-M8"
@@ -94,6 +95,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.typelevel" %%% "cats-core" % catsVersion,
       "org.typelevel" %%% "cats-effect-kernel" % catsEffectVersion,
       "org.scodec" %%% "scodec-bits" % scodecBitsVersion,
+      "co.fs2" %%% "fs2-core" % fs2Version,
       "org.scalameta" %%% "munit" % munitVersion % Test,
       "org.typelevel" %%% "cats-laws" % catsVersion % Test,
       "org.typelevel" %%% "cats-effect" % catsEffectVersion % Test,

--- a/core/js/src/main/scala/bobcats/CryptoPlatform.scala
+++ b/core/js/src/main/scala/bobcats/CryptoPlatform.scala
@@ -19,7 +19,7 @@ package bobcats
 import cats.effect.kernel.Async
 
 private[bobcats] trait CryptoCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): Crypto[F] =
+  def forAsync[F[_]](implicit F: Async[F]): Crypto[F] =
     new UnsealedCrypto[F] {
       override def hash: Hash[F] = Hash[F]
       override def hmac: Hmac[F] = Hmac[F]

--- a/core/js/src/main/scala/bobcats/Hash1Platform.scala
+++ b/core/js/src/main/scala/bobcats/Hash1Platform.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bobcats
+
+import cats.syntax.all._
+import cats.effect.{Async, Resource, Sync}
+import scodec.bits.ByteVector
+import fs2.{Chunk, Pipe, Stream}
+
+private[bobcats] final class SubtleCryptoDigest[F[_]](algorithm: String)(implicit F: Async[F])
+    extends UnsealedHash1[F] {
+
+  import facade.browser._
+
+  override def digest(data: ByteVector): F[ByteVector] =
+    F.fromPromise(F.delay(crypto.subtle.digest(algorithm, data.toUint8Array.buffer)))
+      .map(ByteVector.view)
+
+  override def pipe: Pipe[F, Byte, Byte] = throw new UnsupportedOperationException(
+    "Browsers do not support streaming")
+
+}
+
+private final class NodeCryptoDigest[F[_]](algorithm: String)(implicit F: Sync[F])
+    extends UnsealedHash1[F] {
+
+  override def digest(data: ByteVector): F[ByteVector] =
+    F.pure {
+      // Assume we've checked the algorithm already
+      val hash = facade.node.crypto.createHash(algorithm)
+      hash.update(data.toUint8Array)
+      ByteVector.view(hash.digest())
+    }
+
+  override val pipe: Pipe[F, Byte, Byte] =
+    in =>
+      Stream.eval(F.delay(facade.node.crypto.createHash(algorithm))).flatMap { hash =>
+        in.chunks
+          .fold(hash) { (h, d) =>
+            h.update(d.toUint8Array)
+            h
+          }
+          .flatMap(h => Stream.chunk(Chunk.uint8Array(h.digest())))
+      }
+}
+
+private[bobcats] trait Hash1CompanionPlatform {
+  def fromJSCryptoName[F[_]](alg: String)(implicit F: Sync[F]): F[Hash1[F]] =
+    if (facade.node.crypto.getHashes().contains(alg)) {
+      F.pure(new NodeCryptoDigest(alg)(F))
+    } else {
+      F.raiseError(new NoSuchAlgorithmException(s"${alg} MessageDigest not available"))
+    }
+
+  def forAsync[F[_]: Async](algorithm: HashAlgorithm): Resource[F, Hash1[F]] =
+    if (facade.isNodeJSRuntime) Resource.eval(fromJSCryptoName(algorithm.toStringNodeJS))
+    else {
+      // SubtleCrypto does not have a way of checking the supported hashes
+      Resource.pure(new SubtleCryptoDigest(algorithm.toStringWebCrypto))
+    }
+}

--- a/core/js/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HashPlatform.scala
@@ -36,7 +36,7 @@ private[bobcats] trait HashCompanionPlatform {
       new UnsealedHash[F] {
 
         override def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]] =
-          Resource.make(F.catchNonFatal {
+          Resource.make(F.delay {
             val alg = algorithm.toStringNodeJS
             val hash = facade.node.crypto.createHash(alg)
             new NodeCryptoDigest(hash, alg)

--- a/core/js/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/js/src/main/scala/bobcats/HashPlatform.scala
@@ -42,7 +42,7 @@ private[bobcats] trait HashCompanionPlatform {
             new NodeCryptoDigest(hash, alg)
           })(_ => F.unit)
         override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] =
-          F.catchNonFatal {
+          F.delay {
             val hash = facade.node.crypto.createHash(algorithm.toStringNodeJS)
             hash.update(data.toUint8Array)
             ByteVector.view(hash.digest())

--- a/core/js/src/main/scala/bobcats/SecurityException.scala
+++ b/core/js/src/main/scala/bobcats/SecurityException.scala
@@ -19,6 +19,9 @@ package bobcats
 class GeneralSecurityException(message: String = null, cause: Throwable = null)
     extends Exception(message, cause)
 
+class NoSuchAlgorithmException(message: String = null, cause: Throwable = null)
+    extends GeneralSecurityException(message, cause)
+
 class KeyException(message: String = null, cause: Throwable = null)
     extends GeneralSecurityException(message, cause)
 

--- a/core/js/src/main/scala/bobcats/facade/node/crypto.scala
+++ b/core/js/src/main/scala/bobcats/facade/node/crypto.scala
@@ -24,6 +24,8 @@ import scala.scalajs.js
 @nowarn("msg=never used")
 private[bobcats] trait crypto extends js.Any {
 
+  def getHashes(): js.Array[String] = js.native
+
   def createHash(algorithm: String): Hash = js.native
 
   def createHmac(algorithm: String, key: js.typedarray.Uint8Array): Hmac = js.native

--- a/core/jvm/src/main/scala/bobcats/CryptoPlatform.scala
+++ b/core/jvm/src/main/scala/bobcats/CryptoPlatform.scala
@@ -19,9 +19,9 @@ package bobcats
 import cats.effect.kernel.Async
 
 private[bobcats] trait CryptoCompanionPlatform {
-  implicit def forAsync[F[_]: Async]: Crypto[F] =
+  def forAsync[F[_]: Async]: Crypto[F] =
     new UnsealedCrypto[F] {
-      override def hash: Hash[F] = Hash[F]
+      override def hash: Hash[F] = Hash.forAsync[F]
       override def hmac: Hmac[F] = Hmac[F]
     }
 }

--- a/core/jvm/src/main/scala/bobcats/CryptoPlatform.scala
+++ b/core/jvm/src/main/scala/bobcats/CryptoPlatform.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import cats.effect.kernel.{Async, Sync}
+import cats.effect.kernel.{Async, Resource, Sync}
 
 private[bobcats] trait CryptoCompanionPlatform {
 
@@ -29,5 +29,9 @@ private[bobcats] trait CryptoCompanionPlatform {
   }
 
   def forAsync[F[_]: Async]: F[Crypto[F]] = forSync
+
+  def forSyncResource[F[_]: Sync]: Resource[F, Crypto[F]] = Resource.eval(forSync[F])
+
+  def forAsyncResource[F[_]: Async]: Resource[F, Crypto[F]] = Resource.eval(forSync[F])
 
 }

--- a/core/jvm/src/main/scala/bobcats/Hash1Platform.scala
+++ b/core/jvm/src/main/scala/bobcats/Hash1Platform.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bobcats
+
+import java.security.MessageDigest
+import scodec.bits.ByteVector
+import cats.Applicative
+import cats.effect.Sync
+import fs2.{Chunk, Stream}
+
+private final class JavaSecurityDigest[F[_]](val hash: MessageDigest)(
+    implicit F: Applicative[F])
+    extends UnsealedHash1[F] {
+
+  override def digest(data: ByteVector): F[ByteVector] = F.pure {
+    val h = hash.clone().asInstanceOf[MessageDigest]
+    h.update(data.toByteBuffer)
+    ByteVector.view(h.digest())
+  }
+  override def digest(data: Stream[F, Byte]): Stream[F, Byte] =
+    data
+      .chunks
+      .fold(hash.clone().asInstanceOf[MessageDigest]) { (h, data) =>
+        h.update(data.toByteBuffer)
+        h
+      }
+      .flatMap { h => Stream.chunk(Chunk.array(h.digest())) }
+
+  override def toString = hash.toString
+}
+
+private[bobcats] trait Hash1CompanionPlatform {
+
+  private[bobcats] def fromMessageDigestUnsafe[F[_]: Applicative](
+      digest: MessageDigest): Hash1[F] = new JavaSecurityDigest(digest)
+
+  def fromName[F[_]](name: String)(implicit F: Sync[F]): F[Hash1[F]] = F.delay {
+    val hash = MessageDigest.getInstance(name)
+    fromMessageDigestUnsafe(hash)
+  }
+
+  def apply[F[_]](algorithm: HashAlgorithm)(implicit F: Sync[F]): F[Hash1[F]] = fromName(
+    algorithm.toStringJava)
+
+}

--- a/core/jvm/src/main/scala/bobcats/Hash1Platform.scala
+++ b/core/jvm/src/main/scala/bobcats/Hash1Platform.scala
@@ -19,7 +19,7 @@ package bobcats
 import java.security.{MessageDigest, Provider}
 import scodec.bits.ByteVector
 import cats.Applicative
-import cats.effect.Sync
+import cats.effect.{Resource, Sync}
 import fs2.{Chunk, Pipe, Stream}
 
 private final class JavaSecurityDigest[F[_]](algorithm: String, provider: Provider)(
@@ -59,7 +59,10 @@ private[bobcats] trait Hash1CompanionPlatform {
       new JavaSecurityDigest(name, p)(G)
     }
 
-  def apply[F[_]](algorithm: HashAlgorithm)(implicit F: Sync[F]): F[Hash1[F]] = fromName(
+  def forSync[F[_]](algorithm: HashAlgorithm)(implicit F: Sync[F]): F[Hash1[F]] = fromName(
     algorithm.toStringJava)
+
+  def forSyncResource[F[_]: Sync](algorithm: HashAlgorithm): Resource[F, Hash1[F]] =
+    Resource.eval(forSync[F](algorithm))
 
 }

--- a/core/jvm/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/jvm/src/main/scala/bobcats/HashPlatform.scala
@@ -17,7 +17,7 @@
 package bobcats
 
 import cats.syntax.all._
-import fs2.Stream
+import fs2.{Pipe, Stream}
 import cats.effect.kernel.{Async, Sync}
 import scodec.bits.ByteVector
 
@@ -27,8 +27,8 @@ private[bobcats] trait HashCompanionPlatform {
     new UnsealedHash[F] {
       override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] =
         Hash1[F](algorithm).flatMap(_.digest(data))
-      override def digest(algorithm: HashAlgorithm)(data: Stream[F, Byte]): Stream[F, Byte] =
-        Stream.eval(Hash1[F](algorithm)).flatMap(_.digest(data))
+      override def digestPipe(algorithm: HashAlgorithm): Pipe[F, Byte, Byte] =
+        in => Stream.eval(Hash1[F](algorithm)).flatMap(_.pipe(in))
     }
 
   def forAsync[F[_]](implicit F: Async[F]): Hash[F] = forSync(F)

--- a/core/jvm/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/jvm/src/main/scala/bobcats/HashPlatform.scala
@@ -34,7 +34,7 @@ private[bobcats] trait HashCompanionPlatform {
   private[bobcats] def forSync[F[_]](implicit F: Sync[F]): Hash[F] =
     new UnsealedHash[F] {
       override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] =
-        F.catchNonFatal {
+        F.delay {
           val hash = MessageDigest.getInstance(algorithm.toStringJava)
           hash.update(data.toByteBuffer)
           ByteVector.view(hash.digest())

--- a/core/jvm/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/jvm/src/main/scala/bobcats/HashPlatform.scala
@@ -40,7 +40,7 @@ private[bobcats] trait HashCompanionPlatform {
           ByteVector.view(hash.digest())
         }
       override def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]] = {
-        Resource.make(F.catchNonFatal {
+        Resource.make(F.delay {
           val hash = MessageDigest.getInstance(algorithm.toStringJava)
           new JavaSecurityDigest[F](hash)(F)
         })(_.reset)

--- a/core/jvm/src/main/scala/bobcats/Providers.scala
+++ b/core/jvm/src/main/scala/bobcats/Providers.scala
@@ -27,8 +27,6 @@ private[bobcats] final class Providers(val ps: Array[Provider]) extends AnyVal {
     provider("MessageDigest", name).toRight(
       new NoSuchAlgorithmException(s"${name} MessageDigest not available"))
 
-  def messageDigestThrow(name: String): Provider = ???
-
 }
 
 private[bobcats] object Providers {

--- a/core/jvm/src/main/scala/bobcats/Providers.scala
+++ b/core/jvm/src/main/scala/bobcats/Providers.scala
@@ -27,6 +27,9 @@ private[bobcats] final class Providers(val ps: Array[Provider]) extends AnyVal {
     provider("MessageDigest", name).toRight(
       new NoSuchAlgorithmException(s"${name} MessageDigest not available"))
 
+  def mac(name: String): Either[NoSuchAlgorithmException, Provider] =
+    provider("Mac", name).toRight(new NoSuchAlgorithmException(s"${name} Mac not available"))
+
 }
 
 private[bobcats] object Providers {

--- a/core/jvm/src/main/scala/bobcats/Providers.scala
+++ b/core/jvm/src/main/scala/bobcats/Providers.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bobcats
+
+import java.security.{NoSuchAlgorithmException, Security, Provider}
+
+private[bobcats] final class Providers(val ps: Array[Provider]) extends AnyVal {
+
+  private def provider(service: String, name: String): Option[Provider] =
+    ps.find(provider => provider.getService(service, name) != null)
+
+  def messageDigest(name: String): Either[NoSuchAlgorithmException, Provider] =
+    provider("MessageDigest", name).toRight(new NoSuchAlgorithmException(s"${name} MessageDigest not available"))
+
+  def messageDigestThrow(name: String): Provider = ???
+
+}
+
+private[bobcats] object Providers {
+  def get(): Providers = new Providers(Security.getProviders().clone())
+}

--- a/core/jvm/src/main/scala/bobcats/Providers.scala
+++ b/core/jvm/src/main/scala/bobcats/Providers.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import java.security.{NoSuchAlgorithmException, Security, Provider}
+import java.security.{NoSuchAlgorithmException, Provider, Security}
 
 private[bobcats] final class Providers(val ps: Array[Provider]) extends AnyVal {
 
@@ -24,7 +24,8 @@ private[bobcats] final class Providers(val ps: Array[Provider]) extends AnyVal {
     ps.find(provider => provider.getService(service, name) != null)
 
   def messageDigest(name: String): Either[NoSuchAlgorithmException, Provider] =
-    provider("MessageDigest", name).toRight(new NoSuchAlgorithmException(s"${name} MessageDigest not available"))
+    provider("MessageDigest", name).toRight(
+      new NoSuchAlgorithmException(s"${name} MessageDigest not available"))
 
   def messageDigestThrow(name: String): Provider = ???
 

--- a/core/native/src/main/scala/bobcats/Context.scala
+++ b/core/native/src/main/scala/bobcats/Context.scala
@@ -26,5 +26,3 @@ private[bobcats] object Context {
   def apply[F[_]](implicit F: Sync[F]): Resource[F, Ptr[OSSL_LIB_CTX]] =
     Resource.make(F.delay(OSSL_LIB_CTX_new()))(ctx => F.delay(OSSL_LIB_CTX_free(ctx)))
 }
-
-

--- a/core/native/src/main/scala/bobcats/Context.scala
+++ b/core/native/src/main/scala/bobcats/Context.scala
@@ -16,20 +16,15 @@
 
 package bobcats
 
-import cats.effect.IO
-import munit.CatsEffectSuite
+import openssl._
+import openssl.crypto._
+import scala.scalanative.unsafe._
 
-abstract class CryptoSuite extends CatsEffectSuite {
+import cats.effect.kernel.{Resource, Sync}
 
-  private val cryptoFixture = ResourceSuiteLocalFixture(
-    "crypto",
-    Crypto.forAsync[IO]
-  )
-
-  override def munitFixtures = List(cryptoFixture)
-
-  implicit protected def crypto: Crypto[IO] = cryptoFixture()
-  implicit protected def hash: Hash[IO] = crypto.hash
-  implicit protected def hmac: Hmac[IO] = crypto.hmac
-
+private[bobcats] object Context {
+  def apply[F[_]](implicit F: Sync[F]): Resource[F, Ptr[OSSL_LIB_CTX]] =
+    Resource.make(F.delay(OSSL_LIB_CTX_new()))(ctx => F.delay(OSSL_LIB_CTX_free(ctx)))
 }
+
+

--- a/core/native/src/main/scala/bobcats/CryptoPlatform.scala
+++ b/core/native/src/main/scala/bobcats/CryptoPlatform.scala
@@ -16,12 +16,19 @@
 
 package bobcats
 
-import cats.effect.kernel.Async
+import cats.effect.kernel.{Async, Resource, Sync}
+
+import openssl.crypto._
 
 private[bobcats] trait CryptoCompanionPlatform {
-  implicit def forAsync[F[_]: Async]: Crypto[F] =
-    new UnsealedCrypto[F] {
-      override def hash: Hash[F] = Hash[F]
-      override def hmac: Hmac[F] = Hmac[F]
+  def forSyncResource[F[_]](implicit F: Sync[F]): Resource[F, Crypto[F]] =
+    Resource.make(F.delay(OSSL_LIB_CTX_new()))(ctx => F.delay(OSSL_LIB_CTX_free(ctx))).map {
+      ctx =>
+        new UnsealedCrypto[F] {
+          override def hash: Hash[F] = Hash.forContext(ctx)
+          override def hmac: Hmac[F] = ???
+        }
     }
+
+  def forAsyncResource[F[_]: Async]: Resource[F, Crypto[F]] = forSyncResource[F]
 }

--- a/core/native/src/main/scala/bobcats/Hash1Platform.scala
+++ b/core/native/src/main/scala/bobcats/Hash1Platform.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bobcats
+
+import cats.effect.kernel.{Sync, Resource}
+import scodec.bits.ByteVector
+import scalanative.unsafe._
+import scalanative.unsigned._
+import openssl._
+import openssl.err._
+import openssl.evp._
+import fs2.{Chunk, Pipe, Stream}
+
+private[bobcats] final class NativeEvpDigest[F[_]](digest: Ptr[EVP_MD])(implicit F: Sync[F]) extends UnsealedHash1[F] {
+  def digest(data: ByteVector): F[ByteVector] = {
+    val ctx = EVP_MD_CTX_new()
+    val d = data.toArrayUnsafe
+    try {
+      val md = stackalloc[CUnsignedChar](EVP_MAX_MD_SIZE)
+      val s = stackalloc[CInt]()
+      if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
+        throw Error("EVP_DigestInit_ex", ERR_get_error())
+      }
+      val len = d.length
+      if (EVP_DigestUpdate(ctx, if (len == 0) null else d.at(0), len.toULong) != 1) {
+        throw Error("EVP_DigestUpdate", ERR_get_error())
+      }
+      if (EVP_DigestFinal_ex(ctx, md, s) != 1) {
+        throw Error("EVP_DigestFinal_ex", ERR_get_error())
+      }
+      F.pure(ByteVector.fromPtr(md.asInstanceOf[Ptr[Byte]], s(0).toLong))
+    } catch {
+      case e: Error => F.raiseError(e)
+    } finally {
+      EVP_MD_CTX_free(ctx)
+    }
+  }
+
+  def pipe: Pipe[F, Byte, Byte] = { in =>
+    Stream
+      .bracket(F.delay {
+        val ctx = EVP_MD_CTX_new()
+        if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
+          throw Error("EVP_DigestInit_ex", ERR_get_error())
+        }
+        ctx
+      })(ctx => F.delay(EVP_MD_CTX_free(ctx)))
+      .flatMap { ctx =>
+        in.chunks
+          .evalMap { chunk =>
+            F.delay {
+              val d = chunk.toByteVector.toArrayUnsafe
+              val len = d.length
+              if (EVP_DigestUpdate(ctx, if (len == 0) null else d.at(0), len.toULong) != 1) {
+                throw Error("EVP_DigestUpdate", ERR_get_error())
+              }
+            }
+          }
+          .drain ++ Stream.eval {
+          F.delay {
+            val md = stackalloc[CUnsignedChar](EVP_MAX_MD_SIZE)
+            val s = stackalloc[CInt]()
+
+            if (EVP_DigestFinal_ex(ctx, md, s) != 1) {
+              throw Error("EVP_DigestFinal_ex", ERR_get_error())
+            }
+            Chunk.byteVector(ByteVector.fromPtr(md.asInstanceOf[Ptr[Byte]], s(0).toLong))
+          }
+        }.unchunks
+      }
+  }
+}
+
+private[bobcats] trait Hash1CompanionPlatform {
+
+  private[bobcats] def evpAlgorithm(algorithm: HashAlgorithm): CString = {
+    import HashAlgorithm._
+    algorithm match {
+      case MD5 => c"MD5"
+      case SHA1 => c"SHA1"
+      case SHA256 => c"SHA256"
+      case SHA512 => c"SHA512"
+    }
+  }
+
+  def fromNameResource[F[_]](name: CString)(implicit F: Sync[F]): Resource[F, Hash1[F]] =
+    Resource.make(F.delay {
+      val md = EVP_MD_fetch(null, name, null)
+      md
+    })(md => F.delay(EVP_MD_free(md))).map { md =>
+      new NativeEvpDigest(md)
+    }
+
+  def forSyncResource[F[_] : Sync](algorithm: HashAlgorithm): Resource[F, Hash1[F]] =
+    fromNameResource(evpAlgorithm(algorithm))
+}

--- a/core/native/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/native/src/main/scala/bobcats/HashPlatform.scala
@@ -93,7 +93,7 @@ private[bobcats] trait HashCompanionPlatform {
 
         val digest = evpAlgorithm(algorithm)
 
-        F.catchNonFatal {
+        F.delay {
           val ctx = EVP_MD_CTX_new()
           val d = data.toArrayUnsafe
           try {

--- a/core/native/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/native/src/main/scala/bobcats/HashPlatform.scala
@@ -16,7 +16,8 @@
 
 package bobcats
 
-import cats.effect.kernel.Async
+import scala.scalanative.annotation.alwaysinline
+import cats.effect.kernel.{Async, Resource, Sync}
 import scodec.bits.ByteVector
 import scalanative.unsafe._
 import scalanative.unsigned._
@@ -24,21 +25,75 @@ import openssl._
 import openssl.err._
 import openssl.evp._
 
+private final class NativeEvpDigest[F[_]](val ctx: Ptr[EVP_MD_CTX], digest: Ptr[EVP_MD])(
+    implicit F: Sync[F])
+    extends UnsealedDigest[F] {
+
+  override def update(data: ByteVector): F[Unit] = F.delay {
+
+    val d = data.toArrayUnsafe
+    val len = d.length
+
+    if (EVP_DigestUpdate(ctx, if (len == 0) null else d.at(0), d.length.toULong) != 1) {
+      throw Error("EVP_DigestUpdate", ERR_get_error())
+    }
+  }
+
+  override val reset = F.delay {
+    if (EVP_MD_CTX_reset(ctx) != 1) {
+      throw Error("EVP_MD_Ctx_reset", ERR_get_error())
+    }
+    if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
+      throw Error("EVP_DigestInit_ex", ERR_get_error())
+    }
+  }
+
+  override def get: F[ByteVector] = F.delay {
+    val md = stackalloc[CUnsignedChar](EVP_MAX_MD_SIZE)
+    val s = stackalloc[CInt]()
+
+    if (EVP_DigestFinal_ex(ctx, md, s) != 1) {
+      throw Error("EVP_DigestFinal_ex", ERR_get_error())
+    }
+    ByteVector.fromPtr(md.asInstanceOf[Ptr[Byte]], s(0).toLong)
+  }
+
+  def free: F[Unit] = F.delay(EVP_MD_CTX_free(ctx))
+
+}
+
 private[bobcats] trait HashCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): Hash[F] =
+  implicit def forAsync[F[_]](implicit F: Async[F]): Hash[F] = forSync
+
+  private[bobcats] def forSync[F[_]](implicit F: Sync[F]): Hash[F] =
     new UnsealedHash[F] {
-      override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] = {
 
+      @alwaysinline private def evpAlgorithm(algorithm: HashAlgorithm): Ptr[EVP_MD] = {
         import HashAlgorithm._
-
-        val digest = algorithm match {
+        algorithm match {
           case MD5 => EVP_md5()
           case SHA1 => EVP_sha1()
           case SHA256 => EVP_sha256()
           case SHA512 => EVP_sha512()
         }
+      }
 
-        F.delay {
+      override def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]] = {
+        val digest = evpAlgorithm(algorithm)
+        Resource.make(F.catchNonFatal {
+          val ctx = EVP_MD_CTX_new()
+          if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
+            throw Error("EVP_DigestInit_ex", ERR_get_error())
+          }
+          new NativeEvpDigest(ctx, digest)(F)
+        })(_.free)
+      }
+
+      override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] = {
+
+        val digest = evpAlgorithm(algorithm)
+
+        F.catchNonFatal {
           val ctx = EVP_MD_CTX_new()
           val d = data.toArrayUnsafe
           try {

--- a/core/native/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/native/src/main/scala/bobcats/HashPlatform.scala
@@ -16,104 +16,33 @@
 
 package bobcats
 
-import scala.scalanative.annotation.alwaysinline
-import cats.effect.kernel.{Async, Resource, Sync}
+import cats.effect.kernel.Sync
 import scodec.bits.ByteVector
 import scalanative.unsafe._
-import scalanative.unsigned._
 import openssl._
-import openssl.err._
 import openssl.evp._
-
-private final class NativeEvpDigest[F[_]](val ctx: Ptr[EVP_MD_CTX], digest: Ptr[EVP_MD])(
-    implicit F: Sync[F])
-    extends UnsealedDigest[F] {
-
-  override def update(data: ByteVector): F[Unit] = F.delay {
-
-    val d = data.toArrayUnsafe
-    val len = d.length
-
-    if (EVP_DigestUpdate(ctx, if (len == 0) null else d.at(0), d.length.toULong) != 1) {
-      throw Error("EVP_DigestUpdate", ERR_get_error())
-    }
-  }
-
-  override val reset = F.delay {
-    if (EVP_MD_CTX_reset(ctx) != 1) {
-      throw Error("EVP_MD_Ctx_reset", ERR_get_error())
-    }
-    if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
-      throw Error("EVP_DigestInit_ex", ERR_get_error())
-    }
-  }
-
-  override def get: F[ByteVector] = F.delay {
-    val md = stackalloc[CUnsignedChar](EVP_MAX_MD_SIZE)
-    val s = stackalloc[CInt]()
-
-    if (EVP_DigestFinal_ex(ctx, md, s) != 1) {
-      throw Error("EVP_DigestFinal_ex", ERR_get_error())
-    }
-    ByteVector.fromPtr(md.asInstanceOf[Ptr[Byte]], s(0).toLong)
-  }
-
-  def free: F[Unit] = F.delay(EVP_MD_CTX_free(ctx))
-
-}
+import fs2.{Pipe, Stream}
 
 private[bobcats] trait HashCompanionPlatform {
-  implicit def forAsync[F[_]](implicit F: Async[F]): Hash[F] = forSync
 
-  private[bobcats] def forSync[F[_]](implicit F: Sync[F]): Hash[F] =
+  private[bobcats] def forContext[F[_]](ctx: Ptr[OSSL_LIB_CTX])(implicit F: Sync[F]): Hash[F] =
     new UnsealedHash[F] {
 
-      @alwaysinline private def evpAlgorithm(algorithm: HashAlgorithm): Ptr[EVP_MD] = {
-        import HashAlgorithm._
-        algorithm match {
-          case MD5 => EVP_md5()
-          case SHA1 => EVP_sha1()
-          case SHA256 => EVP_sha256()
-          case SHA512 => EVP_sha512()
-        }
-      }
-
-      override def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]] = {
-        val digest = evpAlgorithm(algorithm)
-        Resource.make(F.delay {
-          val ctx = EVP_MD_CTX_new()
-          if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
-            throw Error("EVP_DigestInit_ex", ERR_get_error())
-          }
-          new NativeEvpDigest(ctx, digest)(F)
-        })(_.free)
-      }
-
       override def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector] = {
-
-        val digest = evpAlgorithm(algorithm)
-
-        F.delay {
-          val ctx = EVP_MD_CTX_new()
-          val d = data.toArrayUnsafe
-          try {
-            val md = stackalloc[CUnsignedChar](EVP_MAX_MD_SIZE)
-            val s = stackalloc[CInt]()
-            if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
-              throw Error("EVP_DigestInit_ex", ERR_get_error())
-            }
-            val len = d.length
-            if (EVP_DigestUpdate(ctx, if (len == 0) null else d.at(0), len.toULong) != 1) {
-              throw Error("EVP_DigestUpdate", ERR_get_error())
-            }
-            if (EVP_DigestFinal_ex(ctx, md, s) != 1) {
-              throw Error("EVP_DigestFinal_ex", ERR_get_error())
-            }
-            ByteVector.fromPtr(md.asInstanceOf[Ptr[Byte]], s(0).toLong)
-          } finally {
-            EVP_MD_CTX_free(ctx)
-          }
-        }
+        val md = EVP_MD_fetch(ctx, Hash1.evpAlgorithm(algorithm), null)
+        // Note, this is eager currently which is why the cleanup is working
+        val digest = new NativeEvpDigest(md).digest(data)
+        EVP_MD_free(md)
+        digest
       }
+
+      override def digestPipe(algorithm: HashAlgorithm): Pipe[F, Byte, Byte] =
+        in => {
+          Stream
+            .bracket(F.delay {
+              EVP_MD_fetch(null, Hash1.evpAlgorithm(algorithm), null)
+            })(md => F.delay(EVP_MD_free(md)))
+            .flatMap { md => in.through(new NativeEvpDigest(md).pipe) }
+        }
     }
 }

--- a/core/native/src/main/scala/bobcats/HashPlatform.scala
+++ b/core/native/src/main/scala/bobcats/HashPlatform.scala
@@ -80,7 +80,7 @@ private[bobcats] trait HashCompanionPlatform {
 
       override def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]] = {
         val digest = evpAlgorithm(algorithm)
-        Resource.make(F.catchNonFatal {
+        Resource.make(F.delay {
           val ctx = EVP_MD_CTX_new()
           if (EVP_DigestInit_ex(ctx, digest, null) != 1) {
             throw Error("EVP_DigestInit_ex", ERR_get_error())

--- a/core/native/src/main/scala/bobcats/openssl/crypto.scala
+++ b/core/native/src/main/scala/bobcats/openssl/crypto.scala
@@ -26,6 +26,16 @@ import scala.annotation.nowarn
 private[bobcats] object crypto {
 
   /**
+   * See [[https://www.openssl.org/docs/man3.1/man3/OSSL_LIB_CTX_new.html]]
+   */
+  def OSSL_LIB_CTX_new(): Ptr[OSSL_LIB_CTX] = extern
+
+  /**
+   * See [[https://www.openssl.org/docs/man3.1/man3/OSSL_LIB_CTX_free.html]]
+   */
+  def OSSL_LIB_CTX_free(ctx: Ptr[OSSL_LIB_CTX]): Unit = extern
+
+  /**
    * See [[https://www.openssl.org/docs/man3.1/man3/CRYPTO_memcmp.html]]
    */
   def CRYPTO_memcmp(a: Ptr[Byte], b: Ptr[Byte], len: CSize): CInt = extern

--- a/core/native/src/main/scala/bobcats/openssl/evp.scala
+++ b/core/native/src/main/scala/bobcats/openssl/evp.scala
@@ -37,6 +37,11 @@ private[bobcats] object evp {
   def EVP_MD_CTX_new(): Ptr[EVP_MD_CTX] = extern
 
   /**
+   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_MD_CTX_reset.html]]
+   */
+  def EVP_MD_CTX_reset(ctx: Ptr[EVP_MD_CTX]): CInt = extern
+
+  /**
    * See [[https://www.openssl.org/docs/man3.1/man3/EVP_MD_CTX_free.html]]
    */
   def EVP_MD_CTX_free(ctx: Ptr[EVP_MD_CTX]): Unit = extern

--- a/core/native/src/main/scala/bobcats/openssl/evp.scala
+++ b/core/native/src/main/scala/bobcats/openssl/evp.scala
@@ -70,26 +70,6 @@ private[bobcats] object evp {
   def EVP_MD_get0_name(md: Ptr[EVP_MD]): CString = extern
 
   /**
-   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_md5.html]]
-   */
-  def EVP_md5(): Ptr[EVP_MD] = extern
-
-  /**
-   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_sha1.html]]
-   */
-  def EVP_sha1(): Ptr[EVP_MD] = extern
-
-  /**
-   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_sha256.html]]
-   */
-  def EVP_sha256(): Ptr[EVP_MD] = extern
-
-  /**
-   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_sha512.html]]
-   */
-  def EVP_sha512(): Ptr[EVP_MD] = extern
-
-  /**
    * See [[https://www.openssl.org/docs/man3.1/man3/EVP_DigestInit_ex.html]]
    */
   def EVP_DigestInit_ex(ctx: Ptr[EVP_MD_CTX], `type`: Ptr[EVP_MD], engine: Ptr[ENGINE]): CInt =

--- a/core/native/src/main/scala/bobcats/openssl/evp.scala
+++ b/core/native/src/main/scala/bobcats/openssl/evp.scala
@@ -32,6 +32,19 @@ private[bobcats] object evp {
   final val EVP_MAX_MD_SIZE = 64
 
   /**
+   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_MD_fetch.html]]
+   */
+  def EVP_MD_fetch(
+      ctx: Ptr[OSSL_LIB_CTX],
+      algorithm: CString,
+      properties: CString): Ptr[EVP_MD] = extern
+
+  /**
+   * See [[https://www.openssl.org/docs/man3.1/man3/EVP_MD_free.html]]
+   */
+  def EVP_MD_free(ctx: Ptr[EVP_MD]): Unit = extern
+
+  /**
    * See [[https://www.openssl.org/docs/man3.1/man3/EVP_MD_CTX_new.html]]
    */
   def EVP_MD_CTX_new(): Ptr[EVP_MD_CTX] = extern

--- a/core/shared/src/main/scala/bobcats/Algorithm.scala
+++ b/core/shared/src/main/scala/bobcats/Algorithm.scala
@@ -52,7 +52,15 @@ object HashAlgorithm {
 }
 
 sealed trait HmacAlgorithm extends Algorithm {
+
+  import HmacAlgorithm._
+
   private[bobcats] def minimumKeyLength: Int
+  private[bobcats] def hashAlgorithm: HashAlgorithm = this match {
+    case SHA1 => HashAlgorithm.SHA1
+    case SHA256 => HashAlgorithm.SHA256
+    case SHA512 => HashAlgorithm.SHA512
+  }
 }
 object HmacAlgorithm {
 

--- a/core/shared/src/main/scala/bobcats/Crypto.scala
+++ b/core/shared/src/main/scala/bobcats/Crypto.scala
@@ -16,8 +16,6 @@
 
 package bobcats
 
-import cats.effect.IO
-
 sealed trait Crypto[F[_]] {
   def hash: Hash[F]
   def hmac: Hmac[F]
@@ -26,9 +24,5 @@ sealed trait Crypto[F[_]] {
 private[bobcats] trait UnsealedCrypto[F[_]] extends Crypto[F]
 
 object Crypto extends CryptoCompanionPlatform {
-
-  implicit def forIO: Crypto[IO] = forAsync
-
   def apply[F[_]](implicit crypto: Crypto[F]): crypto.type = crypto
-
 }

--- a/core/shared/src/main/scala/bobcats/Crypto.scala
+++ b/core/shared/src/main/scala/bobcats/Crypto.scala
@@ -16,6 +16,8 @@
 
 package bobcats
 
+import cats.effect.IO
+
 sealed trait Crypto[F[_]] {
   def hash: Hash[F]
   def hmac: Hmac[F]
@@ -24,6 +26,8 @@ sealed trait Crypto[F[_]] {
 private[bobcats] trait UnsealedCrypto[F[_]] extends Crypto[F]
 
 object Crypto extends CryptoCompanionPlatform {
+
+  implicit def forIO: Crypto[IO] = forAsync
 
   def apply[F[_]](implicit crypto: Crypto[F]): crypto.type = crypto
 

--- a/core/shared/src/main/scala/bobcats/Hash.scala
+++ b/core/shared/src/main/scala/bobcats/Hash.scala
@@ -16,7 +16,6 @@
 
 package bobcats
 
-import cats.effect.IO
 import scodec.bits.ByteVector
 import fs2.Pipe
 
@@ -28,9 +27,5 @@ sealed trait Hash[F[_]] {
 private[bobcats] trait UnsealedHash[F[_]] extends Hash[F]
 
 object Hash extends HashCompanionPlatform {
-
-  implicit def forIO: Hash[IO] = forAsync
-
   def apply[F[_]](implicit hash: Hash[F]): hash.type = hash
-
 }

--- a/core/shared/src/main/scala/bobcats/Hash.scala
+++ b/core/shared/src/main/scala/bobcats/Hash.scala
@@ -18,11 +18,11 @@ package bobcats
 
 import cats.effect.IO
 import scodec.bits.ByteVector
-import fs2.Stream
+import fs2.Pipe
 
 sealed trait Hash[F[_]] {
   def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector]
-  def digest(algorithm: HashAlgorithm)(stream: Stream[F, Byte]): Stream[F, Byte]
+  def digestPipe(algorithm: HashAlgorithm): Pipe[F, Byte, Byte]
 }
 
 private[bobcats] trait UnsealedHash[F[_]] extends Hash[F]

--- a/core/shared/src/main/scala/bobcats/Hash.scala
+++ b/core/shared/src/main/scala/bobcats/Hash.scala
@@ -17,9 +17,38 @@
 package bobcats
 
 import scodec.bits.ByteVector
+import cats.effect.kernel.Resource
+
+/**
+ * Used for incremental hashing.
+ */
+sealed trait Digest[F[_]] {
+
+  /**
+   * Updates the digest context with the provided data.
+   */
+  def update(data: ByteVector): F[Unit]
+
+  /**
+   * Returns the final digest.
+   */
+  def get: F[ByteVector]
+
+  /**
+   * Resets the digest to be used again.
+   */
+  def reset: F[Unit]
+}
+
+private[bobcats] trait UnsealedDigest[F[_]] extends Digest[F]
 
 sealed trait Hash[F[_]] {
   def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector]
+
+  /**
+   * Create a digest with can be updated incrementally.
+   */
+  def incremental(algorithm: HashAlgorithm): Resource[F, Digest[F]]
 }
 
 private[bobcats] trait UnsealedHash[F[_]] extends Hash[F]

--- a/core/shared/src/main/scala/bobcats/Hash1.scala
+++ b/core/shared/src/main/scala/bobcats/Hash1.scala
@@ -16,21 +16,20 @@
 
 package bobcats
 
-import cats.effect.IO
-import scodec.bits.ByteVector
 import fs2.Stream
+import scodec.bits.ByteVector
 
-sealed trait Hash[F[_]] {
-  def digest(algorithm: HashAlgorithm, data: ByteVector): F[ByteVector]
-  def digest(algorithm: HashAlgorithm)(stream: Stream[F, Byte]): Stream[F, Byte]
+/**
+ * Hash for a single algorithm.
+ *
+ * Use this class if you have a specific `HashAlgorithm` known in advance or you're using a
+ * customized algorithm not covered by the `HashAlgorithm` class.
+ */
+sealed trait Hash1[F[_]] {
+  def digest(data: ByteVector): F[ByteVector]
+  def digest(data: Stream[F, Byte]): Stream[F, Byte]
 }
 
-private[bobcats] trait UnsealedHash[F[_]] extends Hash[F]
+private[bobcats] trait UnsealedHash1[F[_]] extends Hash1[F]
 
-object Hash extends HashCompanionPlatform {
-
-  implicit def forIO: Hash[IO] = forAsync
-
-  def apply[F[_]](implicit hash: Hash[F]): hash.type = hash
-
-}
+object Hash1 extends Hash1CompanionPlatform

--- a/core/shared/src/main/scala/bobcats/Hash1.scala
+++ b/core/shared/src/main/scala/bobcats/Hash1.scala
@@ -16,7 +16,7 @@
 
 package bobcats
 
-import fs2.Stream
+import fs2.Pipe
 import scodec.bits.ByteVector
 
 /**
@@ -27,7 +27,7 @@ import scodec.bits.ByteVector
  */
 sealed trait Hash1[F[_]] {
   def digest(data: ByteVector): F[ByteVector]
-  def digest(data: Stream[F, Byte]): Stream[F, Byte]
+  def pipe: Pipe[F, Byte, Byte]
 }
 
 private[bobcats] trait UnsealedHash1[F[_]] extends Hash1[F]

--- a/core/shared/src/test/scala/bobcats/CryptoSuite.scala
+++ b/core/shared/src/test/scala/bobcats/CryptoSuite.scala
@@ -16,15 +16,14 @@
 
 package bobcats
 
-import cats.effect.{IO, Resource}
+import cats.effect.IO
 import munit.CatsEffectSuite
 
 trait CryptoSuite extends CatsEffectSuite {
 
   private val cryptoFixture = ResourceSuiteLocalFixture(
     "crypto",
-    // TODO: If we want to pool, which would be quite nice. This _ought_ to return a resouce
-    Resource.make(Crypto.forAsync[IO])(_ => IO.unit)
+    Crypto.forAsyncResource[IO]
   )
 
   override def munitFixtures = List(cryptoFixture)
@@ -33,4 +32,3 @@ trait CryptoSuite extends CatsEffectSuite {
   implicit def hash: Hash[IO] = crypto.hash
 
 }
-

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -72,6 +72,6 @@ class HashSuite extends CryptoSuite {
     SHA512,
     hex"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")
 
-  testVector(MD5, hex"9e107d9d372bb6826bd81d3542a419d6", ignoredRuntimes = Set("Browser"))
+  testVector(MD5, hex"9e107d9d372bb6826bd81d3542a419d6", ignoredRuntimes = Set("Firefox", "Chrome"))
 
 }

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -42,7 +42,7 @@ class HashSuite extends CryptoSuite {
           .compile
           .to(ByteVector)
           .assertEquals(expect) *> Hash1
-          .forSync[IO](algorithm)
+          .forAsync[IO](algorithm)
           .use(_.digest(data))
           .assertEquals(expect)
     }

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -17,7 +17,7 @@
 package bobcats
 
 import cats.effect.IO
-import scodec.bits.ByteVector
+import scodec.bits._
 import fs2.{Chunk, Stream}
 
 class HashSuite extends CryptoSuite {
@@ -30,47 +30,46 @@ class HashSuite extends CryptoSuite {
       algorithm: HashAlgorithm,
       name: String,
       data: ByteVector,
-      expect: String,
+      expect: ByteVector,
       ignoredRuntimes: Set[String]) =
     test(s"$algorithm for $name vector") {
       val runtime = BuildInfo.runtime
       assume(!ignoredRuntimes.contains(runtime), s"${runtime} does not support ${algorithm}")
-      val bytes = ByteVector.fromHex(expect).get
-      Hash[IO].digest(algorithm, data).assertEquals(bytes) *>
+      Hash[IO].digest(algorithm, data).assertEquals(expect) *>
         Stream
           .chunk(Chunk.byteVector(data))
           .through(Hash[IO].digestPipe(algorithm))
           .compile
           .to(ByteVector)
-          .assertEquals(bytes) *> Hash1
-          .forSyncResource[IO](algorithm)
+          .assertEquals(expect) *> Hash1
+          .forSync[IO](algorithm)
           .use(_.digest(data))
-          .assertEquals(bytes)
+          .assertEquals(expect)
     }
 
   def testVector(
       algorithm: HashAlgorithm,
-      expect: String,
+      expect: ByteVector,
       ignoredRuntimes: Set[String] = Set()) =
     testHash(algorithm, "example", data, expect, ignoredRuntimes)
 
   def testEmpty(
       algorithm: HashAlgorithm,
-      expect: String,
+      expect: ByteVector,
       ignoredRuntimes: Set[String] = Set()) =
     testHash(algorithm, "empty", ByteVector.empty, expect, ignoredRuntimes)
 
-  testVector(SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
-  testEmpty(SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709")
-  testVector(SHA256, "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
-  testEmpty(SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+  testVector(SHA1, hex"2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+  testEmpty(SHA1, hex"da39a3ee5e6b4b0d3255bfef95601890afd80709")
+  testVector(SHA256, hex"d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
+  testEmpty(SHA256, hex"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
   testVector(
     SHA512,
-    "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
+    hex"07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
   testEmpty(
     SHA512,
-    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")
+    hex"cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")
 
-  testVector(MD5, "9e107d9d372bb6826bd81d3542a419d6", ignoredRuntimes = Set("Browser"))
+  testVector(MD5, hex"9e107d9d372bb6826bd81d3542a419d6", ignoredRuntimes = Set("Browser"))
 
 }

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -16,90 +16,58 @@
 
 package bobcats
 
-import cats.effect.{IO, MonadCancelThrow}
-import cats.Functor
-import cats.syntax.all._
-import munit.CatsEffectSuite
+import cats.effect.IO
 import scodec.bits.ByteVector
+import fs2.{Chunk, Stream}
 
-import scala.reflect.ClassTag
-
-class HashSuite extends CatsEffectSuite {
+class HashSuite extends CryptoSuite {
 
   import HashAlgorithm._
 
   val data = ByteVector.encodeAscii("The quick brown fox jumps over the lazy dog").toOption.get
 
-  def testHash[F[_]: Hash: cats.Monad](algorithm: HashAlgorithm, expect: String)(
-      implicit ct: ClassTag[F[Nothing]]) =
-    test(s"$algorithm with ${ct.runtimeClass.getSimpleName()}") {
-      Hash[F].digest(algorithm, data).map { obtained =>
-        assertEquals(
-          obtained,
-          ByteVector.fromHex(expect).get
-        )
-      }
-
-      Hash1[cats.effect.IO](algorithm).flatMap { digest =>
-        digest.digest(data).map { obtained =>
-          assertEquals(
-            obtained,
-            ByteVector.fromHex(expect).get
-          )
-        }
-      }
+  def testHash(
+      algorithm: HashAlgorithm,
+      name: String,
+      data: ByteVector,
+      expect: String,
+      ignoredRuntimes: Set[String]) =
+    test(s"$algorithm for $name vector") {
+      val runtime = BuildInfo.runtime
+      assume(!ignoredRuntimes.contains(runtime), s"${runtime} does not support ${algorithm}")
+      val bytes = ByteVector.fromHex(expect).get
+      Hash[IO].digest(algorithm, data).assertEquals(bytes) *>
+        Stream
+          .chunk(Chunk.byteVector(data))
+          .through(Hash[IO].digestPipe(algorithm))
+          .compile
+          .to(ByteVector)
+          .assertEquals(bytes)
     }
 
-  // def testHashIncremental[F[_]: Hash: MonadCancelThrow](
-  //     algorithm: HashAlgorithm,
-  //     expect: String)(implicit ct: ClassTag[F[Nothing]]) =
-  //   test(s"incremental $algorithm with ${ct.runtimeClass.getSimpleName()}") {
-  //     Hash[F].incremental(algorithm).use { digest =>
-  //       (digest.update(data) *> digest.reset *> digest.update(data) *> digest.get)
-  //         .map { obtained =>
-  //           assertEquals(
-  //             obtained,
-  //             ByteVector.fromHex(expect).get
-  //           )
-  //         }
-  //     }
-  //   }
+  def testVector(
+      algorithm: HashAlgorithm,
+      expect: String,
+      ignoredRuntimes: Set[String] = Set()) =
+    testHash(algorithm, "example", data, expect, ignoredRuntimes)
 
-  def testEmpty[F[_]: Hash: Functor](algorithm: HashAlgorithm, expect: String)(
-      implicit ct: ClassTag[F[Nothing]]) =
-    test(s"empty $algorithm with ${ct.runtimeClass.getSimpleName()}") {
-      Hash[F].digest(algorithm, ByteVector.empty).map { obtained =>
-        assertEquals(
-          obtained,
-          ByteVector.fromHex(expect).get
-        )
-      }
-    }
+  def testEmpty(
+      algorithm: HashAlgorithm,
+      expect: String,
+      ignoredRuntimes: Set[String] = Set()) =
+    testHash(algorithm, "empty", ByteVector.empty, expect, ignoredRuntimes)
 
-  def tests[F[_]: Hash: MonadCancelThrow](implicit ct: ClassTag[F[Nothing]]) = {
-    if (Set("JVM", "NodeJS", "Native").contains(BuildInfo.runtime))
-      testHash[F](MD5, "9e107d9d372bb6826bd81d3542a419d6")
+  testVector(SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+  testEmpty(SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709")
+  testVector(SHA256, "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
+  testEmpty(SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+  testVector(
+    SHA512,
+    "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
+  testEmpty(
+    SHA512,
+    "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")
 
-    // if (Set("JVM", "NodeJS", "Native").contains(BuildInfo.runtime)) {
-    //   testHashIncremental[F](MD5, "9e107d9d372bb6826bd81d3542a419d6")
-    //   testHashIncremental[F](SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
-    // }
-
-    testHash[F](SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
-    testEmpty[F](SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709")
-
-    testHash[F](SHA256, "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592")
-    testEmpty[F](SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-    testHash[F](
-      SHA512,
-      "07e547d9586f6a73f73fbac0435ed76951218fb7d0c8d788a309d785436bbb642e93a252a954f23912547d1e8a3b5ed6e1bfd7097821233fa0538f3db854fee6")
-
-    testEmpty[F](SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-    testEmpty[F](
-      SHA512,
-      "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e")
-  }
-
-  tests[IO]
+  testVector(MD5, "9e107d9d372bb6826bd81d3542a419d6", ignoredRuntimes = Set("Browser"))
 
 }

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -16,8 +16,8 @@
 
 package bobcats
 
+import cats.effect.{IO, MonadCancelThrow}
 import cats.Functor
-import cats.effect.IO
 import cats.syntax.all._
 import munit.CatsEffectSuite
 import scodec.bits.ByteVector
@@ -39,12 +39,26 @@ class HashSuite extends CatsEffectSuite {
           ByteVector.fromHex(expect).get
         )
       }
+    }
 
+  def testHashIncremental[F[_]: Hash: MonadCancelThrow](
+      algorithm: HashAlgorithm,
+      expect: String)(implicit ct: ClassTag[F[Nothing]]) =
+    test(s"incremental $algorithm with ${ct.runtimeClass.getSimpleName()}") {
+      Hash[F].incremental(algorithm).use { digest =>
+        (digest.update(data) *> digest.reset *> digest.update(data) *> digest.get)
+          .map { obtained =>
+            assertEquals(
+              obtained,
+              ByteVector.fromHex(expect).get
+            )
+          }
+      }
     }
 
   def testEmpty[F[_]: Hash: Functor](algorithm: HashAlgorithm, expect: String)(
       implicit ct: ClassTag[F[Nothing]]) =
-    test(s"$algorithm with ${ct.runtimeClass.getSimpleName()}") {
+    test(s"empty $algorithm with ${ct.runtimeClass.getSimpleName()}") {
       Hash[F].digest(algorithm, ByteVector.empty).map { obtained =>
         assertEquals(
           obtained,
@@ -53,9 +67,14 @@ class HashSuite extends CatsEffectSuite {
       }
     }
 
-  def tests[F[_]: Hash: Functor](implicit ct: ClassTag[F[Nothing]]) = {
+  def tests[F[_]: Hash: MonadCancelThrow](implicit ct: ClassTag[F[Nothing]]) = {
     if (Set("JVM", "NodeJS", "Native").contains(BuildInfo.runtime))
       testHash[F](MD5, "9e107d9d372bb6826bd81d3542a419d6")
+
+    if (Set("JVM", "NodeJS", "Native").contains(BuildInfo.runtime)) {
+      testHashIncremental[F](MD5, "9e107d9d372bb6826bd81d3542a419d6")
+      testHashIncremental[F](SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
+    }
 
     testHash[F](SHA1, "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12")
     testEmpty[F](SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709")

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -31,9 +31,9 @@ class HashSuite extends CryptoSuite {
       name: String,
       data: ByteVector,
       expect: ByteVector,
-      ignoredRuntimes: Set[String]) =
-    test(s"$algorithm for $name vector") {
-      val runtime = BuildInfo.runtime
+      ignoredRuntimes: Set[String]) = {
+    val runtime = BuildInfo.runtime
+    test(s"$algorithm for $name vector on ${runtime}") {
       assume(!ignoredRuntimes.contains(runtime), s"${runtime} does not support ${algorithm}")
       val streamTest = Stream
         .chunk(Chunk.byteVector(data))
@@ -47,6 +47,7 @@ class HashSuite extends CryptoSuite {
         .assertEquals(expect) *> (if (Set("Firefox", "Chrome").contains(runtime)) IO.unit
                                   else streamTest)
     }
+  }
 
   def testVector(
       algorithm: HashAlgorithm,

--- a/core/shared/src/test/scala/bobcats/HashSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HashSuite.scala
@@ -42,6 +42,9 @@ class HashSuite extends CryptoSuite {
           .through(Hash[IO].digestPipe(algorithm))
           .compile
           .to(ByteVector)
+          .assertEquals(bytes) *> Hash1
+          .forSyncResource[IO](algorithm)
+          .use(_.digest(data))
           .assertEquals(bytes)
     }
 

--- a/core/shared/src/test/scala/bobcats/HotpSuite.scala
+++ b/core/shared/src/test/scala/bobcats/HotpSuite.scala
@@ -16,15 +16,10 @@
 
 package bobcats
 
-import cats.Functor
 import cats.effect.IO
-import cats.syntax.functor._
-import munit.CatsEffectSuite
 import scodec.bits._
 
-import scala.reflect.ClassTag
-
-class HotpSuite extends CatsEffectSuite {
+class HotpSuite extends CryptoSuite {
 
   val key = hex"3132333435363738393031323334353637383930"
 
@@ -32,16 +27,12 @@ class HotpSuite extends CatsEffectSuite {
     755224, 287082, 359152, 969429, 338314, 254676, 287922, 162583, 399871, 520489
   )
 
-  def tests[F[_]: Hmac: Functor](implicit ct: ClassTag[F[Nothing]]) = {
-    expectedValues.zipWithIndex.foreach {
-      case (expected, counter) =>
-        test(s"RFC4226 test case ${counter} for ${ct.runtimeClass.getSimpleName()}") {
-          Hotp
-            .generate[F](SecretKeySpec(key, HmacAlgorithm.SHA1), counter.toLong, digits = 6)
-            .map { obtained => assertEquals(obtained, expected) }
-        }
-    }
+  expectedValues.zipWithIndex.foreach {
+    case (expected, counter) =>
+      test(s"RFC4226 test case ${counter}") {
+        Hotp
+          .generate[IO](SecretKeySpec(key, HmacAlgorithm.SHA1), counter.toLong, digits = 6)
+          .map { obtained => assertEquals(obtained, expected) }
+      }
   }
-
-  tests[IO]
 }


### PR DESCRIPTION
Fixes #181. Each API is subtly different, but in general we have a new/update/finalize/reset.

The WebCrypto API for browsers doesn't support incremental hashes yet; we could either shim it (i.e. build up the `ByteVector` in memory) or just throw. I feel that it is better to throw so that the user does not have an expectation of memory usage, but it might be a PITA for anyone cross-compling.