### PR TITLE
Make OpenSSL link to "libcrypto" on Windows

### DIFF
--- a/core/native/src/main/scala/bobcats/openssl/crypto.scala
+++ b/core/native/src/main/scala/bobcats/openssl/crypto.scala
@@ -20,8 +20,7 @@ package openssl
 import scala.scalanative.unsafe._
 
 @extern
-@link("crypto")
-private[bobcats] object crypto {
+private[bobcats] trait crypto {
 
   /**
    * See [[https://www.openssl.org/docs/man3.1/man3/OSSL_LIB_CTX_new.html]]

--- a/core/native/src/main/scala/bobcats/openssl/err.scala
+++ b/core/native/src/main/scala/bobcats/openssl/err.scala
@@ -21,8 +21,7 @@ import scala.scalanative.unsafe._
 import scala.scalanative.unsigned._
 
 @extern
-@link("crypto")
-private[bobcats] object err {
+private[bobcats] trait err {
 
   def ERR_get_error(): ULong = extern
   def ERR_func_error_string(e: ULong): CString = extern

--- a/core/native/src/main/scala/bobcats/openssl/evp.scala
+++ b/core/native/src/main/scala/bobcats/openssl/evp.scala
@@ -20,8 +20,7 @@ package openssl
 import scala.scalanative.unsafe._
 
 @extern
-@link("crypto")
-private[bobcats] object evp {
+private[bobcats] trait evp {
 
   type EVP_MD_CTX
   type EVP_MD

--- a/core/native/src/main/scala/bobcats/openssl/package.scala
+++ b/core/native/src/main/scala/bobcats/openssl/package.scala
@@ -18,6 +18,7 @@ package bobcats
 
 import scala.scalanative.annotation.alwaysinline
 import scala.scalanative.unsafe._
+import scala.scalanative.meta.LinktimeInfo.isWindows
 
 package object openssl {
 
@@ -42,4 +43,32 @@ package object openssl {
       param._5 = returnSize
     }
   }
+
+  private[bobcats] object platformCompat {
+    @extern @link("libcrypto")
+    object cryptoWin64 extends crypto
+    @extern @link("libcrypto")
+    object errWin64 extends err
+    @extern @link("libcrypto")
+    object evpWin64 extends evp
+
+    @extern @link("crypto")
+    object cryptoDefault extends crypto
+    @extern @link("crypto")
+    object errDefault extends err
+    @extern @link("crypto")
+    object evpDefault extends evp
+  }
+
+  private[bobcats] final val crypto = 
+      if (isWindows) platformCompat.cryptoWin64
+      else platformCompat.cryptoDefault
+
+  private[bobcats] final val err = 
+      if (isWindows) platformCompat.errWin64
+      else platformCompat.errDefault
+
+  private[bobcats] final val evp = 
+      if (isWindows) platformCompat.evpWin64
+      else platformCompat.evpDefault
 }

--- a/core/native/src/main/scala/bobcats/openssl/package.scala
+++ b/core/native/src/main/scala/bobcats/openssl/package.scala
@@ -60,15 +60,15 @@ package object openssl {
     object evpDefault extends evp
   }
 
-  private[bobcats] final val crypto = 
-      if (isWindows) platformCompat.cryptoWin64
-      else platformCompat.cryptoDefault
+  private[bobcats] final val crypto =
+    if (isWindows) platformCompat.cryptoWin64
+    else platformCompat.cryptoDefault
 
-  private[bobcats] final val err = 
-      if (isWindows) platformCompat.errWin64
-      else platformCompat.errDefault
+  private[bobcats] final val err =
+    if (isWindows) platformCompat.errWin64
+    else platformCompat.errDefault
 
-  private[bobcats] final val evp = 
-      if (isWindows) platformCompat.evpWin64
-      else platformCompat.evpDefault
+  private[bobcats] final val evp =
+    if (isWindows) platformCompat.evpWin64
+    else platformCompat.evpDefault
 }


### PR DESCRIPTION
Windows binary distributions of OpenSSL use `libcrypto.lib` instead of `crypto.lib` (this pattern seems quite common for reasons that I do not understand).

This PR updates the code to use the correct linking flag depending on the OS.

Tested by checking that the unit tests ran both on Mac OS and on Windows 11 (Using [Shining Light's OpenSSL binary distribution](https://slproweb.com/products/Win32OpenSSL.html))